### PR TITLE
Fix chatbot document search filtering

### DIFF
--- a/backend/chat/tests.py
+++ b/backend/chat/tests.py
@@ -1,3 +1,77 @@
+from unittest.mock import patch
+
 from django.test import TestCase
 
-# Create your tests here.
+from chat.models import ChatBotInstance, Company, Document
+from chat.utils.embeddings import search_documents
+
+
+class SearchDocumentsTestCase(TestCase):
+    def setUp(self):
+        self.company = Company.objects.create(name="Test Company")
+        self.primary_chatbot = ChatBotInstance.objects.create(
+            company=self.company,
+            name="Assistant A",
+        )
+        self.secondary_chatbot = ChatBotInstance.objects.create(
+            company=self.company,
+            name="Assistant B",
+        )
+
+        self.matching_embedding = self._unit_vector(0)
+        self.alt_embedding = self._unit_vector(1)
+        self.secondary_embedding = self._unit_vector(2)
+
+        self.primary_document = Document.objects.create(
+            company=self.company,
+            chatbot=self.primary_chatbot,
+            source="jira",
+            source_id="DOC-1",
+            content="Primary chatbot document",
+            embedding=self.matching_embedding,
+        )
+        self.primary_document_additional = Document.objects.create(
+            company=self.company,
+            chatbot=self.primary_chatbot,
+            source="jira",
+            source_id="DOC-2",
+            content="Another document for the primary chatbot",
+            embedding=self.alt_embedding,
+        )
+        self.secondary_document = Document.objects.create(
+            company=self.company,
+            chatbot=self.secondary_chatbot,
+            source="jira",
+            source_id="DOC-3",
+            content="Secondary chatbot document",
+            embedding=self.secondary_embedding,
+        )
+
+    def _unit_vector(self, index):
+        vector = [0.0] * 1536
+        vector[index] = 1.0
+        return vector
+
+    @patch("chat.utils.embeddings.embed_text")
+    def test_search_documents_filters_results_by_chatbot(self, mock_embed_text):
+        mock_embed_text.return_value = self.matching_embedding
+
+        results = search_documents(
+            company_id=self.company.id,
+            chatbot_id=self.primary_chatbot.id,
+            query="What documents exist?",
+            top_k=5,
+        )
+
+        mock_embed_text.assert_called_once_with("What documents exist?")
+
+        self.assertEqual(len(results), 2)
+
+        result_ids = {result["id"] for result in results}
+
+        self.assertSetEqual(
+            result_ids,
+            {self.primary_document.id, self.primary_document_additional.id},
+        )
+
+        self.assertNotIn(self.secondary_document.id, result_ids)

--- a/backend/chat/utils/embeddings.py
+++ b/backend/chat/utils/embeddings.py
@@ -1,7 +1,8 @@
 import openai
 from django.conf import settings
 from chat.models import Document
-from django.db import connection
+from django.db.models import ExpressionWrapper, F, FloatField, Value
+from pgvector.django import CosineDistance
 
 def embed_text(text: str) -> list:
     """
@@ -58,27 +59,30 @@ def search_documents(company_id, chatbot_id, query, top_k=5):
     # 1. Embed the query text
     query_embedding = embed_text(query)
 
-    # 2. Run similarity search
-    with connection.cursor() as cursor:
-        cursor.execute("""
-            SELECT id, source, source_id, content,
-                   1 - (embedding <=> %s::vector) AS similarity
-            FROM chat_document
-            WHERE company_id = %s
-            ORDER BY embedding <=> %s::vector
-            LIMIT %s
-        """, [query_embedding, company_id, chatbot_id, query_embedding, top_k])
+    # 2. Run similarity search using pgvector helpers
+    queryset = (
+        Document.objects
+        .filter(company_id=company_id, chatbot_id=chatbot_id)
+        .annotate(distance=CosineDistance("embedding", query_embedding))
+        .annotate(
+            similarity=ExpressionWrapper(
+                Value(1.0) - F("distance"),
+                output_field=FloatField(),
+            )
+        )
+        .order_by("distance")
+    )
 
-        rows = cursor.fetchall()
+    rows = queryset[:top_k]
 
     # 3. Return structured results
     return [
         {
-            "id": row[0],
-            "source": row[1],       # "jira", "confluence", or "github"
-            "source_id": row[2],    # ticket id, page id, file path
-            "content": row[3],
-            "similarity": float(row[4]),
+            "id": doc.id,
+            "source": doc.source,       # "jira", "confluence", or "github"
+            "source_id": doc.source_id,    # ticket id, page id, file path
+            "content": doc.content,
+            "similarity": float(doc.similarity) if doc.similarity is not None else None,
         }
-        for row in rows
+        for doc in rows
     ]


### PR DESCRIPTION
## Summary
- replace the raw SQL chatbot document search with pgvector ORM helpers to bind parameters safely
- ensure chatbot-scoped filtering is applied when ranking and returning search results
- add a regression test seeding multiple chatbots to confirm only the matching chatbot's documents are returned

## Testing
- not run (PostgreSQL service unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1e18402d0832a98eeb17ad64cb3e7