### PR TITLE
Restrict company access to user context

### DIFF
--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -5,7 +5,7 @@ from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework_nested.routers import NestedDefaultRouter
 
 router = DefaultRouter()
-router.register(r'companies', CompanyViewSet)
+router.register(r'companies', CompanyViewSet, basename='company')
 router.register(r'chatBots', ChatBotInstanceViewSet, basename='chatBot')
 router.register(r'feedbacks', ChatFeedbackViewSet, basename='feedback')
 router.register(r'users', UserViewSet, basename='user')


### PR DESCRIPTION
## Summary
- limit the company viewset to a request-aware queryset and gate modifications to admins
- register the company routes with an explicit basename for router resolution
- expand API tests to cover company access restrictions for non-admin users

## Testing
- `python manage.py test chat.tests` *(fails: database connection to PostgreSQL is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d419315c832a97deea5235bce234