### PR TITLE
Validate sync payloads without mutating request data

### DIFF
--- a/backend/chat/tests.py
+++ b/backend/chat/tests.py
@@ -198,6 +198,21 @@ class SyncCredentialPermissionTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_jira_sync_create_accepts_valid_payload(self):
+        url = f"/api/chatBots/{self.chatbot.id}/jiraSyncs/"
+        payload = {
+            'board_url': 'https://example.atlassian.net',
+            'credential_id': self.tenant_credential.id,
+            'sync_interval': JiraSync.SYNC_INTERVAL_CHOICES[0][0],
+        }
+
+        response = self.client.post(url, payload, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(JiraSync.objects.filter(chatBot=self.chatbot).count(), 1)
+        sync = JiraSync.objects.get(chatBot=self.chatbot)
+        self.assertEqual(sync.credential, self.tenant_credential)
+
     def test_jira_sync_update_rejects_foreign_credential(self):
         sync = JiraSync.objects.create(
             chatBot=self.chatbot,
@@ -225,6 +240,21 @@ class SyncCredentialPermissionTests(TestCase):
         response = self.client.post(url, payload, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_confluence_sync_create_accepts_valid_payload(self):
+        url = f"/api/chatBots/{self.chatbot.id}/confluenceSyncs/"
+        payload = {
+            'space_url': 'https://example.atlassian.net/wiki',
+            'credential_id': self.tenant_credential.id,
+            'sync_interval': ConfluenceSync.SYNC_INTERVAL_CHOICES[0][0],
+        }
+
+        response = self.client.post(url, payload, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(ConfluenceSync.objects.filter(chatBot=self.chatbot).count(), 1)
+        sync = ConfluenceSync.objects.get(chatBot=self.chatbot)
+        self.assertEqual(sync.credential, self.tenant_credential)
 
     def test_confluence_sync_update_rejects_foreign_credential(self):
         sync = ConfluenceSync.objects.create(

--- a/backend/chat/views.py
+++ b/backend/chat/views.py
@@ -121,21 +121,15 @@ class JiraSyncViewSet(viewsets.ModelViewSet):
         except ChatBotInstance.DoesNotExist:
             raise PermissionDenied("Invalid chatbot or not in your company")
 
-        # Include the chatbot in the validated data
-        mutable_data = request.data.copy()
-        mutable_data['chatBot'] = chatBot.id
+        self._validate_request_credential_id(request.data)
 
-        self._validate_request_credential_id(mutable_data)
-
-        serializer = self.get_serializer(data=mutable_data)
-
-        if not serializer.is_valid():
-            logger.error("Validation error: %s", serializer.errors)
-            return Response(serializer.errors, status=400)
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
 
         self._validate_credential(serializer.validated_data.get('credential'))
-        serializer.save(chatBot=chatBot)
-        return Response(serializer.data, status=201)
+        sync = serializer.save(chatBot=chatBot)
+        response_serializer = self.get_serializer(sync)
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
     def update(self, request, *args, **kwargs):
         self._validate_request_credential_id(request.data)
@@ -188,21 +182,15 @@ class ConfluenceSyncViewSet(viewsets.ModelViewSet):
         except ChatBotInstance.DoesNotExist:
             raise PermissionDenied("Invalid chatbot or not in your company")
 
-        # Inject chatBot into the data explicitly
-        mutable_data = request.data.copy()
-        mutable_data['chatBot'] = chatBot.id
+        self._validate_request_credential_id(request.data)
 
-        self._validate_request_credential_id(mutable_data)
-
-        serializer = self.get_serializer(data=mutable_data)
-
-        if not serializer.is_valid():
-            logger.error("ConfluenceSync Validation Error: %s", serializer.errors)
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
 
         self._validate_credential(serializer.validated_data.get('credential'))
-        serializer.save(chatBot=chatBot)
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
+        sync = serializer.save(chatBot=chatBot)
+        response_serializer = self.get_serializer(sync)
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
     def update(self, request, *args, **kwargs):
         self._validate_request_credential_id(request.data)


### PR DESCRIPTION
## Summary
- validate Jira and Confluence sync creation payloads using serializer validation
- persist the chatbot relationship via serializer.save without altering request data
- cover successful sync creation with new API tests alongside existing permission checks

## Testing
- python manage.py test chat.tests.SyncCredentialPermissionTests

------
https://chatgpt.com/codex/tasks/task_e_68e2ecdd55c4832a9d82da47e356e51a