### PR TITLE
Make frontend API base URL configurable

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -21,6 +21,8 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile.prod
+      args:
+        VITE_API_BASE_URL: https://harrishs.ca/api
     container_name: frontend
     restart: unless-stopped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
   frontend:
     build:
       context: ./frontend
+      args:
+        VITE_API_BASE_URL: http://localhost:8000/api
     container_name: frontend
     volumes:
       - ./frontend:/app
@@ -49,6 +51,7 @@ services:
       - "5173:5173"
     environment:
       - CHOKIDAR_USEPOLLING=true
+      - VITE_API_BASE_URL=http://localhost:8000/api
     command: npm run dev
     stdin_open: true
     tty: true

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,9 @@
 # Use Node.js base image
 FROM node:20-alpine
 
+ARG VITE_API_BASE_URL=/api
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+
 # Set working directory
 WORKDIR /app
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -2,14 +2,15 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 
+ARG VITE_API_BASE_URL=/api
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+
 # Copy package files and install deps (ci = clean, reproducible)
 COPY package*.json ./
 RUN npm ci
 
 # Copy the rest of the source and build
 COPY . .
-# If you reference Vite env vars, set them here (build-time):
-# ENV VITE_API_BASE_URL=/api
 RUN npm run build
 
 # --- Stage 2: Serve static files with Nginx ---

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,12 +1,35 @@
-# React + Vite
+# Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This directory contains the React + Vite single-page application for the ChatBot project.
 
-Currently, two official plugins are available:
+## Environment variables
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+The application reads Vite environment variables at build and dev-server time. Variables must be prefixed with `VITE_` to be exposed to the browser.
 
-## Expanding the ESLint configuration
+| Variable | Default | Description |
+| --- | --- | --- |
+| `VITE_API_BASE_URL` | `/api` | Base URL used by Axios when issuing API calls. Set this when the frontend is served from a different origin than the backend. |
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+When the frontend and backend are deployed on the same origin (for example behind the production Caddy reverse proxy), you can rely on the default `/api` path. For local development where the Django API is served from `localhost:8000`, set `VITE_API_BASE_URL=http://localhost:8000/api` before starting Vite.
+
+## Local development
+
+```bash
+npm install
+VITE_API_BASE_URL=http://localhost:8000/api npm run dev
+```
+
+This starts the Vite dev server on [http://localhost:5173](http://localhost:5173). The environment variable can also be stored in a `.env.local` file if you prefer.
+
+## Production build
+
+```bash
+npm install
+VITE_API_BASE_URL=https://example.com/api npm run build
+```
+
+The resulting static assets in `dist/` can be served by any static web server. Remember that the value baked into the build cannot be changed at runtime, so set `VITE_API_BASE_URL` appropriately before building.
+
+## Docker builds
+
+Both `Dockerfile` (development) and `Dockerfile.prod` (production) accept a `VITE_API_BASE_URL` build argument. This allows Compose or other orchestrators to pass the correct API endpoint while keeping `/api` as the default fallback.

--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -1,7 +1,9 @@
 import axios from "axios";
 
+const baseURL = import.meta.env?.VITE_API_BASE_URL || "/api";
+
 const api = axios.create({
-	baseURL: "http://localhost:8000/api",
+        baseURL,
 });
 
 api.interceptors.request.use((config) => {


### PR DESCRIPTION
## Summary
- read the API base URL from `import.meta.env.VITE_API_BASE_URL` with a `/api` fallback in the Axios client
- document the new variable and wire it through the Vite and Docker build configurations
- update docker-compose setups to provide sensible defaults for development and production deployments

## Testing
- VITE_API_BASE_URL=https://api.example.com npm run build
- VITE_API_BASE_URL=https://api.example.com npm run dev -- --host (verified served module via curl)


------
https://chatgpt.com/codex/tasks/task_e_68e464a102ec832abe693360faa13f5c