### PR TITLE
Parameterize production domains

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,1 +1,26 @@
 # ChatBot
+
+## Production configuration
+
+`docker-compose.prod.yml` and the production `Caddyfile` rely on a small set of
+environment variables so the stack can be reconfigured without editing source
+files. Define these in an `.env` file (automatically picked up by
+`docker-compose`) or export them in your shell before running the compose
+commands:
+
+| Variable | Example | Purpose |
+| --- | --- | --- |
+| `FRONTEND_DOMAIN` | `example.com` | Primary hostname served by Caddy and allowed by the backend. |
+| `FRONTEND_WWW_DOMAIN` | `www.example.com` | Secondary hostname (set to the same value as `FRONTEND_DOMAIN` if not using a second host). |
+| `API_BASE_URL` | `https://example.com/api` | Public URL where the API is exposed; used for the frontend build arg and runtime CORS settings. |
+
+These variables drive the configuration for:
+
+* Frontend build arguments (`VITE_API_BASE_URL`) so the SPA points to the
+  correct API endpoint.
+* Backend host, CSRF, and CORS allow-lists for Django.
+* Caddy virtual hosts via environment placeholders in `deploy/Caddyfile`.
+
+When deploying, ensure the environment variables are populated before running
+`docker compose -f docker-compose.prod.yml up -d` so every service receives the
+correct values.

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,4 +1,4 @@
-harrishs.ca, www.harrishs.ca {
+{$FRONTEND_DOMAIN}, {$FRONTEND_WWW_DOMAIN} {
   encode zstd gzip
 
   # Optional: provide an email for ACME/Let's Encrypt notices

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,6 +9,9 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    environment:
+      - FRONTEND_DOMAIN=${FRONTEND_DOMAIN}
+      - FRONTEND_WWW_DOMAIN=${FRONTEND_WWW_DOMAIN}
     volumes:
       - ./deploy/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
@@ -22,7 +25,7 @@ services:
       context: ./frontend
       dockerfile: Dockerfile.prod
       args:
-        VITE_API_BASE_URL: https://harrishs.ca/api
+        VITE_API_BASE_URL: ${API_BASE_URL}
     container_name: frontend
     restart: unless-stopped
 
@@ -36,9 +39,9 @@ services:
       - ./backend/.env.production
     environment:
       - ENV=production
-      - ALLOWED_HOSTS=harrishs.ca,www.harrishs.ca
-      - CSRF_TRUSTED_ORIGINS=https://harrishs.ca,https://www.harrishs.ca
-      - CORS_ALLOWED_ORIGINS=https://harrishs.ca,https://www.harrishs.ca
+      - ALLOWED_HOSTS=${FRONTEND_DOMAIN},${FRONTEND_WWW_DOMAIN}
+      - CSRF_TRUSTED_ORIGINS=https://${FRONTEND_DOMAIN},https://${FRONTEND_WWW_DOMAIN}
+      - CORS_ALLOWED_ORIGINS=https://${FRONTEND_DOMAIN},https://${FRONTEND_WWW_DOMAIN}
     depends_on:
       - db
 


### PR DESCRIPTION
## Summary
- make production compose configuration use environment variables for domains and API base URL
- template the Caddyfile so domains are injected from the same variable set
- document the required deployment environment variables in the README

## Testing
- not run (configuration-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e7052a818c832a9deaa5a858a816b8