### PR TITLE
Update sync ingestion tests for async worker

### DIFF
--- a/backend/chat/tests/test_sync_ingestion.py
+++ b/backend/chat/tests/test_sync_ingestion.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.core.management import call_command
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -8,14 +9,13 @@ from rest_framework.test import APITestCase
 from chat.models import (
     ChatBotInstance,
     Company,
-    ConfluencePage,
     ConfluenceSync,
     Document,
     GitCredential,
     GitRepoSync,
-    JiraComment,
-    JiraIssue,
     JiraSync,
+    SyncJob,
+    SyncStatusMixin,
 )
 
 
@@ -38,79 +38,160 @@ class SyncIngestionTests(APITestCase):
         )
         self.api_prefix = "/api"
 
+    @patch("chat.management.commands.process_sync_jobs.run_jira_sync")
     @patch("chat.utils.embeddings.embed_text", return_value=[0.1] * 1536)
-    def test_jira_sync_now_creates_documents(self, mock_embed_text):
+    def test_jira_sync_now_creates_documents(self, mock_embed_text, mock_run_jira_sync):
         sync = JiraSync.objects.create(
             chatBot=self.chatbot,
             board_url="https://example.atlassian.net/jira/software/c/projects/TEST/boards/1",
         )
 
-        def fake_fetch(fetch_sync):
-            issue = JiraIssue.objects.create(
-                sync=fetch_sync,
-                issue_key="TEST-1",
-                summary="Sample issue",
-                description="Issue description",
-                status="To Do",
-                created_at=timezone.now(),
-                updated_at=timezone.now(),
+        def fake_run(sync_id, job_id=None):
+            self.assertEqual(sync_id, sync.id)
+            sync_obj = JiraSync.objects.get(pk=sync_id)
+            issue_embedding = mock_embed_text("jira-issue")
+            comment_embedding = mock_embed_text("jira-comment")
+            Document.objects.create(
+                company=sync_obj.chatBot.company,
+                chatbot=sync_obj.chatBot,
+                source="jira_issue",
+                source_id="TEST-1",
+                content="Sample issue",
+                embedding=issue_embedding,
             )
-            comment = JiraComment.objects.create(
-                issue=issue,
-                author="Commenter",
+            Document.objects.create(
+                company=sync_obj.chatBot.company,
+                chatbot=sync_obj.chatBot,
+                source="jira_comment",
+                source_id="TEST-1-comment",
                 content="A helpful comment",
-                created_at=timezone.now(),
+                embedding=comment_embedding,
             )
-            return [(issue, [comment])]
+            sync_obj.sync_status = JiraSync.Status.SUCCEEDED
+            sync_obj.sync_status_message = "Processed 1 issues and ingested 2 documents."
+            sync_obj.last_sync_time = timezone.now()
+            if job_id:
+                sync_obj.current_job_id = job_id
+            sync_obj.save(
+                update_fields=[
+                    "sync_status",
+                    "sync_status_message",
+                    "last_sync_time",
+                    "current_job_id",
+                ]
+            )
+            return 1, 2
 
-        with patch("chat.views.fetch_jira_issues", side_effect=fake_fetch):
-            url = f"{self.api_prefix}/chatBots/{self.chatbot.pk}/jiraSyncs/{sync.pk}/sync_now/"
-            response = self.client.post(url)
+        mock_run_jira_sync.side_effect = fake_run
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["documents_ingested"], 2)
+        url = f"{self.api_prefix}/chatBots/{self.chatbot.pk}/jiraSyncs/{sync.pk}/sync_now/"
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertIn("job_id", response.data)
+        job_id = response.data["job_id"]
+
+        call_command("process_sync_jobs", once=True)
+
+        mock_run_jira_sync.assert_called_once_with(sync.id, job_id=str(job_id))
         self.assertEqual(Document.objects.count(), 2)
+
+        job = SyncJob.objects.get(pk=int(job_id))
+        self.assertEqual(job.status, SyncStatusMixin.Status.SUCCEEDED)
+        self.assertEqual(job.status_message, "Processed 1 Jira issues (2 documents ingested).")
+
+        sync.refresh_from_db()
+        self.assertEqual(sync.sync_status, JiraSync.Status.SUCCEEDED)
+        self.assertEqual(sync.sync_status_message, "Processed 1 issues and ingested 2 documents.")
+        self.assertIsNotNone(sync.last_sync_time)
+
+        status_url = f"{self.api_prefix}/chatBots/{self.chatbot.pk}/jiraSyncs/{sync.pk}/status/"
+        status_response = self.client.get(status_url)
+        self.assertEqual(status_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(status_response.data["job_id"], str(job_id))
+        self.assertEqual(status_response.data["status"], JiraSync.Status.SUCCEEDED)
+        self.assertEqual(status_response.data["message"], "Processed 1 issues and ingested 2 documents.")
+        self.assertEqual(status_response.data["job_status"], SyncStatusMixin.Status.SUCCEEDED)
+        self.assertEqual(
+            status_response.data["job_message"],
+            "Processed 1 Jira issues (2 documents ingested).",
+        )
         self.assertEqual(mock_embed_text.call_count, 2)
 
+    @patch("chat.management.commands.process_sync_jobs.run_confluence_sync")
     @patch("chat.utils.embeddings.embed_text", return_value=[0.2] * 1536)
-    def test_confluence_sync_now_creates_documents(self, mock_embed_text):
+    def test_confluence_sync_now_creates_documents(self, mock_embed_text, mock_run_confluence_sync):
         sync = ConfluenceSync.objects.create(
             chatBot=self.chatbot,
             space_url="https://example.atlassian.net/wiki/spaces/CONF/pages/1",
         )
 
-        def fake_fetch(fetch_sync):
-            page = ConfluencePage.objects.create(
-                sync=fetch_sync,
-                title="Welcome",
+        def fake_run(sync_id, job_id=None):
+            self.assertEqual(sync_id, sync.id)
+            sync_obj = ConfluenceSync.objects.get(pk=sync_id)
+            embedding = mock_embed_text("confluence-page")
+            Document.objects.create(
+                company=sync_obj.chatBot.company,
+                chatbot=sync_obj.chatBot,
+                source="confluence",
+                source_id="CONF-1",
                 content="Welcome to the space",
-                url="https://example.atlassian.net/wiki/spaces/CONF/pages/1",
-                last_updated=timezone.now(),
+                embedding=embedding,
             )
-            return [page]
+            sync_obj.sync_status = ConfluenceSync.Status.SUCCEEDED
+            sync_obj.sync_status_message = "Processed 1 pages and ingested 1 documents."
+            sync_obj.last_sync_time = timezone.now()
+            if job_id:
+                sync_obj.current_job_id = job_id
+            sync_obj.save(
+                update_fields=[
+                    "sync_status",
+                    "sync_status_message",
+                    "last_sync_time",
+                    "current_job_id",
+                ]
+            )
+            return 1, 1
 
-        with patch("chat.views.fetch_confluence_pages", side_effect=fake_fetch):
-            url = f"{self.api_prefix}/chatBots/{self.chatbot.pk}/confluenceSyncs/{sync.pk}/sync_now/"
-            response = self.client.post(url)
+        mock_run_confluence_sync.side_effect = fake_run
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["documents_ingested"], 1)
+        url = f"{self.api_prefix}/chatBots/{self.chatbot.pk}/confluenceSyncs/{sync.pk}/sync_now/"
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertIn("job_id", response.data)
+        job_id = response.data["job_id"]
+
+        call_command("process_sync_jobs", once=True)
+
+        mock_run_confluence_sync.assert_called_once_with(sync.id, job_id=str(job_id))
         self.assertEqual(Document.objects.count(), 1)
+
+        job = SyncJob.objects.get(pk=int(job_id))
+        self.assertEqual(job.status, SyncStatusMixin.Status.SUCCEEDED)
+        self.assertEqual(job.status_message, "Processed 1 Confluence pages (1 documents ingested).")
+
+        sync.refresh_from_db()
+        self.assertEqual(sync.sync_status, ConfluenceSync.Status.SUCCEEDED)
+        self.assertEqual(sync.sync_status_message, "Processed 1 pages and ingested 1 documents.")
+        self.assertIsNotNone(sync.last_sync_time)
+
+        status_url = f"{self.api_prefix}/chatBots/{self.chatbot.pk}/confluenceSyncs/{sync.pk}/status/"
+        status_response = self.client.get(status_url)
+        self.assertEqual(status_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(status_response.data["job_id"], str(job_id))
+        self.assertEqual(status_response.data["status"], ConfluenceSync.Status.SUCCEEDED)
+        self.assertEqual(status_response.data["message"], "Processed 1 pages and ingested 1 documents.")
+        self.assertEqual(status_response.data["job_status"], SyncStatusMixin.Status.SUCCEEDED)
+        self.assertEqual(
+            status_response.data["job_message"],
+            "Processed 1 Confluence pages (1 documents ingested).",
+        )
         self.assertEqual(mock_embed_text.call_count, 1)
 
-    @patch("chat.utils.github._get_last_commit_date")
-    @patch("chat.utils.github._get_blob")
-    @patch("chat.utils.github._list_tree")
-    @patch("chat.utils.github.decrypt_api_key", return_value="token")
+    @patch("chat.management.commands.process_sync_jobs.run_git_repo_sync")
     @patch("chat.utils.embeddings.embed_text", return_value=[0.3] * 1536)
-    def test_github_sync_now_creates_documents(
-        self,
-        mock_embed_text,
-        mock_decrypt,
-        mock_list_tree,
-        mock_get_blob,
-        mock_get_last_commit,
-    ):
+    def test_github_sync_now_creates_documents(self, mock_embed_text, mock_run_git_repo_sync):
         credential = GitCredential(
             company=self.company,
             name="GitHub",
@@ -126,16 +207,67 @@ class SyncIngestionTests(APITestCase):
             branch="main",
         )
 
-        mock_list_tree.return_value = [{"type": "blob", "path": "README.md", "sha": "abc123"}]
-        mock_get_blob.return_value = b"Hello world"
-        mock_get_last_commit.return_value = timezone.now()
-
         url = f"{self.api_prefix}/chatBots/{self.chatbot.pk}/gitRepoSyncs/{sync.pk}/sync_now/"
         response = self.client.post(url)
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["documents_ingested"], 1)
+        def fake_run(sync_id, job_id=None):
+            self.assertEqual(sync_id, sync.id)
+            sync_obj = GitRepoSync.objects.get(pk=sync_id)
+            embedding = mock_embed_text("github-file")
+            Document.objects.create(
+                company=sync_obj.chatBot.company,
+                chatbot=sync_obj.chatBot,
+                source="github",
+                source_id="README.md",
+                content="Hello world",
+                embedding=embedding,
+            )
+            sync_obj.sync_status = GitRepoSync.Status.SUCCEEDED
+            sync_obj.sync_status_message = "Processed 1 files and ingested 1 documents."
+            sync_obj.last_sync_time = timezone.now()
+            if job_id:
+                sync_obj.current_job_id = job_id
+            sync_obj.save(
+                update_fields=[
+                    "sync_status",
+                    "sync_status_message",
+                    "last_sync_time",
+                    "current_job_id",
+                ]
+            )
+            return 1, 1
+
+        mock_run_git_repo_sync.side_effect = fake_run
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertIn("job_id", response.data)
+        job_id = response.data["job_id"]
+
+        call_command("process_sync_jobs", once=True)
+
+        mock_run_git_repo_sync.assert_called_once_with(sync.id, job_id=str(job_id))
         self.assertEqual(Document.objects.count(), 1)
+
+        job = SyncJob.objects.get(pk=int(job_id))
+        self.assertEqual(job.status, SyncStatusMixin.Status.SUCCEEDED)
+        self.assertEqual(job.status_message, "Processed 1 repository files (1 documents ingested).")
+
+        sync.refresh_from_db()
+        self.assertEqual(sync.sync_status, GitRepoSync.Status.SUCCEEDED)
+        self.assertEqual(sync.sync_status_message, "Processed 1 files and ingested 1 documents.")
+        self.assertIsNotNone(sync.last_sync_time)
+
+        status_url = f"{self.api_prefix}/chatBots/{self.chatbot.pk}/gitRepoSyncs/{sync.pk}/status/"
+        status_response = self.client.get(status_url)
+        self.assertEqual(status_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(status_response.data["job_id"], str(job_id))
+        self.assertEqual(status_response.data["status"], GitRepoSync.Status.SUCCEEDED)
+        self.assertEqual(status_response.data["message"], "Processed 1 files and ingested 1 documents.")
+        self.assertEqual(status_response.data["job_status"], SyncStatusMixin.Status.SUCCEEDED)
+        self.assertEqual(
+            status_response.data["job_message"],
+            "Processed 1 repository files (1 documents ingested).",
+        )
         self.assertEqual(mock_embed_text.call_count, 1)
 
     def test_jira_sync_now_logs_errors(self):
@@ -144,11 +276,45 @@ class SyncIngestionTests(APITestCase):
             board_url="https://example.atlassian.net/jira/software/c/projects/TEST/boards/1",
         )
 
-        with patch("chat.views.fetch_jira_issues", side_effect=RuntimeError("boom")):
-            with self.assertLogs("chat.views", level="ERROR") as logs:
-                url = f"{self.api_prefix}/chatBots/{self.chatbot.pk}/jiraSyncs/{sync.pk}/sync_now/"
-                response = self.client.post(url)
+        url = f"{self.api_prefix}/chatBots/{self.chatbot.pk}/jiraSyncs/{sync.pk}/sync_now/"
+        response = self.client.post(url)
 
-        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
-        self.assertEqual(response.data["detail"], "Failed to sync Jira.")
-        self.assertTrue(any("Failed to sync Jira" in message for message in logs.output))
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        job_id = response.data["job_id"]
+
+        def failing_run(sync_id, job_id=None):
+            self.assertEqual(sync_id, sync.id)
+            sync_obj = JiraSync.objects.get(pk=sync_id)
+            sync_obj.sync_status = JiraSync.Status.FAILED
+            sync_obj.sync_status_message = "Failed to sync Jira."
+            if job_id:
+                sync_obj.current_job_id = job_id
+            sync_obj.save(
+                update_fields=["sync_status", "sync_status_message", "current_job_id"],
+            )
+            raise RuntimeError("boom")
+
+        with patch(
+            "chat.management.commands.process_sync_jobs.run_jira_sync",
+            side_effect=failing_run,
+        ) as mock_run:
+            call_command("process_sync_jobs", once=True)
+
+        mock_run.assert_called_once_with(sync.id, job_id=str(job_id))
+
+        job = SyncJob.objects.get(pk=int(job_id))
+        self.assertEqual(job.status, SyncStatusMixin.Status.FAILED)
+        self.assertEqual(job.status_message, "Failed to sync Jira.")
+
+        sync.refresh_from_db()
+        self.assertEqual(sync.sync_status, JiraSync.Status.FAILED)
+        self.assertEqual(sync.sync_status_message, "Failed to sync Jira.")
+
+        status_url = f"{self.api_prefix}/chatBots/{self.chatbot.pk}/jiraSyncs/{sync.pk}/status/"
+        status_response = self.client.get(status_url)
+        self.assertEqual(status_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(status_response.data["status"], JiraSync.Status.FAILED)
+        self.assertEqual(status_response.data["message"], "Failed to sync Jira.")
+        self.assertEqual(status_response.data["job_status"], SyncStatusMixin.Status.FAILED)
+        self.assertEqual(status_response.data["job_message"], "Failed to sync Jira.")
+        self.assertEqual(Document.objects.count(), 0)


### PR DESCRIPTION
## Summary
- adapt sync ingestion API tests to enqueue jobs, execute the worker, and validate job/status responses
- stub task-layer sync helpers to create documents and assert embeddings without touching external services

## Testing
- python manage.py test chat.tests.test_sync_ingestion

------
https://chatgpt.com/codex/tasks/task_e_68e865aca960832a881260f4c56e9bf7