### PR TITLE
Add sync job polling and status messaging

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import api from "../api/axios";
 
@@ -41,6 +42,7 @@ export function AuthProvider({ children }) {
                         try {
                                 await fetchSession();
                         } catch (error) {
+                                console.error("Failed to refresh session", error);
                                 if (active) {
                                         setUser(null);
                                 }

--- a/frontend/src/pages/ChatBotSyncs.jsx
+++ b/frontend/src/pages/ChatBotSyncs.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import api from "../api/axios";
 
@@ -41,37 +41,249 @@ function ChatBotSyncs() {
 		sync_interval: "manual",
 	});
 	const [editingGit, setEditingGit] = useState(null);
-	const [editingGitData, setEditingGitData] = useState({
-		repo_full_name: "",
-		branch: "main",
-		credential_id: "",
-		sync_interval: "manual",
-	});
+        const [editingGitData, setEditingGitData] = useState({
+                repo_full_name: "",
+                branch: "main",
+                credential_id: "",
+                sync_interval: "manual",
+        });
 
-	const loadData = async () => {
-		try {
-			const [jiraRes, confRes, credRes, gitRes, gitCredRes] = await Promise.all(
-				[
-					api.get(`/chatBots/${chatBotId}/jiraSyncs/`),
-					api.get(`/chatBots/${chatBotId}/confluenceSyncs/`),
-					api.get("/credentials/"),
-					api.get(`/chatBots/${chatBotId}/gitRepoSyncs/`),
-					api.get("/gitCredentials/"),
-				]
-			);
-			setJiraSyncs(jiraRes.data);
-			setConfluenceSyncs(confRes.data);
-			setCredentials(credRes.data);
-			setGitSyncs(gitRes.data);
-			setGitCredentials(gitCredRes.data);
-		} catch (err) {
-			console.error("Error loading syncs", err);
-		}
-	};
+        const [jobDetails, setJobDetails] = useState({});
+        const pollTimeouts = useRef({});
+        const activePolls = useRef({});
 
-	useEffect(() => {
-		loadData();
-	}, [chatBotId]);
+        const makeJobKey = (type, id) => `${type}-${id}`;
+
+        const updateSync = useCallback((type, id, updates) => {
+                const setters = {
+                        jira: setJiraSyncs,
+                        confluence: setConfluenceSyncs,
+                        git: setGitSyncs,
+                };
+
+                const setter = setters[type];
+                if (!setter) {
+                        return;
+                }
+
+                setter((prev) =>
+                        prev.map((sync) =>
+                                sync.id === id
+                                        ? {
+                                                  ...sync,
+                                                  ...updates,
+                                          }
+                                        : sync
+                        )
+                );
+        }, []);
+
+        const loadData = useCallback(async () => {
+                try {
+                        const [jiraRes, confRes, credRes, gitRes, gitCredRes] = await Promise.all(
+                                [
+                                        api.get(`/chatBots/${chatBotId}/jiraSyncs/`),
+                                        api.get(`/chatBots/${chatBotId}/confluenceSyncs/`),
+                                        api.get("/credentials/"),
+                                        api.get(`/chatBots/${chatBotId}/gitRepoSyncs/`),
+                                        api.get("/gitCredentials/"),
+                                ]
+                        );
+                        setJiraSyncs(jiraRes.data);
+                        setConfluenceSyncs(confRes.data);
+                        setCredentials(credRes.data);
+                        setGitSyncs(gitRes.data);
+                        setGitCredentials(gitCredRes.data);
+                } catch (err) {
+                        console.error("Error loading syncs", err);
+                }
+        }, [chatBotId]);
+
+        const stopPolling = useCallback((key) => {
+                if (pollTimeouts.current[key]) {
+                        clearTimeout(pollTimeouts.current[key]);
+                        delete pollTimeouts.current[key];
+                }
+                delete activePolls.current[key];
+                setJobDetails((prev) => {
+                        if (!prev[key]) {
+                                return prev;
+                        }
+                        return {
+                                ...prev,
+                                [key]: {
+                                        ...prev[key],
+                                        isPolling: false,
+                                },
+                        };
+                });
+        }, []);
+
+        const pollStatus = useCallback(
+                async (type, id, jobId) => {
+                        const key = makeJobKey(type, id);
+                        const resource =
+                                type === "jira"
+                                        ? "jiraSyncs"
+                                        : type === "confluence"
+                                        ? "confluenceSyncs"
+                                        : "gitRepoSyncs";
+
+                        const poll = async () => {
+                                try {
+                                        const { data } = await api.get(
+                                                `/chatBots/${chatBotId}/${resource}/${id}/status/`
+                                        );
+
+                                        updateSync(type, id, {
+                                                sync_status: data.status,
+                                                sync_status_message: data.message,
+                                                current_job_id: data.job_id,
+                                                job_status: data.job_status,
+                                                job_message: data.job_message,
+                                        });
+
+                                        setJobDetails((prev) => ({
+                                                ...prev,
+                                                [key]: {
+                                                        ...(prev[key] || {}),
+                                                        jobId: data.job_id,
+                                                        jobStatus: data.job_status || data.status,
+                                                        jobMessage: data.job_message || data.message,
+                                                        isPolling: true,
+                                                },
+                                        }));
+
+                                        if (data.job_id && jobId && data.job_id !== jobId) {
+                                                stopPolling(key);
+                                                return;
+                                        }
+
+                                        const terminalStatuses = ["succeeded", "failed"];
+                                        if (
+                                                terminalStatuses.includes(data.job_status) ||
+                                                terminalStatuses.includes(data.status)
+                                        ) {
+                                                stopPolling(key);
+                                                if (data.job_status === "failed" || data.status === "failed") {
+                                                        window.alert(data.job_message || data.message || "Sync failed.");
+                                                }
+                                                await loadData();
+                                                return;
+                                        }
+                                } catch (error) {
+                                        console.error("Error polling sync status", error);
+                                        stopPolling(key);
+                                        return;
+                                }
+
+                                pollTimeouts.current[key] = setTimeout(poll, 2000);
+                        };
+
+                        stopPolling(key);
+                        activePolls.current[key] = true;
+                        setJobDetails((prev) => ({
+                                ...prev,
+                                [key]: {
+                                        ...(prev[key] || {}),
+                                        jobId,
+                                        jobStatus: "queued",
+                                        isPolling: true,
+                                },
+                        }));
+                        await poll();
+                },
+                [chatBotId, loadData, stopPolling, updateSync],
+        );
+
+        useEffect(() => {
+                loadData();
+        }, [loadData]);
+
+        useEffect(() => () => {
+                Object.values(pollTimeouts.current).forEach((timeoutId) => {
+                        clearTimeout(timeoutId);
+                });
+                pollTimeouts.current = {};
+                activePolls.current = {};
+        }, []);
+
+        useEffect(() => {
+                jiraSyncs.forEach((sync) => {
+                        if (
+                                sync.current_job_id &&
+                                ["queued", "running"].includes(sync.sync_status)
+                        ) {
+                                const key = makeJobKey("jira", sync.id);
+                                if (!activePolls.current[key]) {
+                                        pollStatus("jira", sync.id, sync.current_job_id);
+                                }
+                        }
+                });
+        }, [jiraSyncs, pollStatus]);
+
+        useEffect(() => {
+                confluenceSyncs.forEach((sync) => {
+                        if (
+                                sync.current_job_id &&
+                                ["queued", "running"].includes(sync.sync_status)
+                        ) {
+                                const key = makeJobKey("confluence", sync.id);
+                                if (!activePolls.current[key]) {
+                                        pollStatus("confluence", sync.id, sync.current_job_id);
+                                }
+                        }
+                });
+        }, [confluenceSyncs, pollStatus]);
+
+        useEffect(() => {
+                gitSyncs.forEach((sync) => {
+                        if (
+                                sync.current_job_id &&
+                                ["queued", "running"].includes(sync.sync_status)
+                        ) {
+                                const key = makeJobKey("git", sync.id);
+                                if (!activePolls.current[key]) {
+                                        pollStatus("git", sync.id, sync.current_job_id);
+                                }
+                        }
+                });
+        }, [gitSyncs, pollStatus]);
+
+        const triggerSyncNow = useCallback(
+                async (type, id) => {
+                        try {
+                                const resource =
+                                        type === "jira"
+                                                ? "jiraSyncs"
+                                                : type === "confluence"
+                                                ? "confluenceSyncs"
+                                                : "gitRepoSyncs";
+                                const endpoint = `/chatBots/${chatBotId}/${resource}/${id}/sync_now/`;
+                                const { data } = await api.post(endpoint);
+                                updateSync(type, id, {
+                                        sync_status: data.status,
+                                        sync_status_message: data.message,
+                                        current_job_id: data.job_id,
+                                });
+                                const key = makeJobKey(type, id);
+                                setJobDetails((prev) => ({
+                                        ...prev,
+                                        [key]: {
+                                                jobId: data.job_id,
+                                                jobStatus: data.status || "queued",
+                                                jobMessage: data.message,
+                                                isPolling: true,
+                                        },
+                                }));
+                                await pollStatus(type, id, data.job_id);
+                        } catch (error) {
+                                console.error("Error triggering sync", error);
+                                window.alert("Failed to queue sync job. Please check the configuration and try again.");
+                        }
+                },
+                [chatBotId, pollStatus, updateSync],
+        );
 
 	const submitJira = async (e) => {
 		e.preventDefault();
@@ -187,23 +399,20 @@ function ChatBotSyncs() {
 		}
 	};
 
-	const syncJiraNow = async (id) => {
-		await api.post(`/chatBots/${chatBotId}/jiraSyncs/${id}/sync_now/`);
-		loadData();
-	};
+        const syncJiraNow = async (id) => {
+                await triggerSyncNow("jira", id);
+        };
 
-	const syncConfluenceNow = async (id) => {
-		await api.post(`/chatBots/${chatBotId}/confluenceSyncs/${id}/sync_now/`);
-		loadData();
-	};
+        const syncConfluenceNow = async (id) => {
+                await triggerSyncNow("confluence", id);
+        };
 
-	const syncGitNow = async (id) => {
-		await api.post(`/chatBots/${chatBotId}/gitRepoSyncs/${id}/sync_now/`);
-		loadData();
-	};
+        const syncGitNow = async (id) => {
+                await triggerSyncNow("git", id);
+        };
 
-	return (
-		<div style={{ padding: "2rem" }}>
+        return (
+                <div style={{ padding: "2rem" }}>
 			<h2>Jira Syncs</h2>
 			<form onSubmit={submitJira}>
 				<input
@@ -294,12 +503,12 @@ function ChatBotSyncs() {
 							</form>
 						) : (
 							<>
-								{sync.board_url} (Credential: {sync.credential?.name})
-								<button
-									onClick={() => {
-										setEditingJira(sync.id);
-										setEditingJiraData({
-											board_url: sync.board_url,
+                                                                {sync.board_url} (Credential: {sync.credential?.name})
+                                                                <button
+                                                                        onClick={() => {
+                                                                                setEditingJira(sync.id);
+                                                                                setEditingJiraData({
+                                                                                        board_url: sync.board_url,
 											credential_id: sync.credential?.id,
 											sync_interval: sync.sync_interval,
 										});
@@ -309,11 +518,32 @@ function ChatBotSyncs() {
 								</button>
 							</>
 						)}
-						<button onClick={() => deleteJira(sync.id)}>Delete</button>
-						<button onClick={() => syncJiraNow(sync.id)}>Sync Now</button>
-					</li>
-				))}
-			</ul>
+                                                <div>
+                                                        <strong>Status:</strong> {sync.sync_status || "idle"}
+                                                        {jobDetails[makeJobKey("jira", sync.id)]?.isPolling && (
+                                                                <span style={{ marginLeft: "0.5rem" }}>
+                                                                        Checking status...
+                                                                </span>
+                                                        )}
+                                                </div>
+                                                {sync.sync_status_message && (
+                                                        <div>{sync.sync_status_message}</div>
+                                                )}
+                                                {jobDetails[makeJobKey("jira", sync.id)]?.jobMessage && (
+                                                        <div>
+                                                                <em>
+                                                                        Job message: {
+                                                                                jobDetails[makeJobKey("jira", sync.id)]
+                                                                                        ?.jobMessage
+                                                                        }
+                                                                </em>
+                                                        </div>
+                                                )}
+                                                <button onClick={() => deleteJira(sync.id)}>Delete</button>
+                                                <button onClick={() => syncJiraNow(sync.id)}>Sync Now</button>
+                                        </li>
+                                ))}
+                        </ul>
 
 			<h2>Confluence Syncs</h2>
 			<form onSubmit={submitConfluence}>
@@ -411,12 +641,12 @@ function ChatBotSyncs() {
 							</form>
 						) : (
 							<>
-								{sync.space_url} (Credential: {sync.credential?.name})
-								<button
-									onClick={() => {
-										setEditingConfluence(sync.id);
-										setEditingConfluenceData({
-											space_url: sync.space_url,
+                                                                {sync.space_url} (Credential: {sync.credential?.name})
+                                                                <button
+                                                                        onClick={() => {
+                                                                                setEditingConfluence(sync.id);
+                                                                                setEditingConfluenceData({
+                                                                                        space_url: sync.space_url,
 											credential_id: sync.credential?.id,
 											sync_interval: sync.sync_interval,
 										});
@@ -426,11 +656,32 @@ function ChatBotSyncs() {
 								</button>
 							</>
 						)}
-						<button onClick={() => deleteConfluence(sync.id)}>Delete</button>
-						<button onClick={() => syncConfluenceNow(sync.id)}>Sync Now</button>
-					</li>
-				))}
-			</ul>
+                                                <div>
+                                                        <strong>Status:</strong> {sync.sync_status || "idle"}
+                                                        {jobDetails[makeJobKey("confluence", sync.id)]?.isPolling && (
+                                                                <span style={{ marginLeft: "0.5rem" }}>
+                                                                        Checking status...
+                                                                </span>
+                                                        )}
+                                                </div>
+                                                {sync.sync_status_message && (
+                                                        <div>{sync.sync_status_message}</div>
+                                                )}
+                                                {jobDetails[makeJobKey("confluence", sync.id)]?.jobMessage && (
+                                                        <div>
+                                                                <em>
+                                                                        Job message: {
+                                                                                jobDetails[makeJobKey("confluence", sync.id)]
+                                                                                        ?.jobMessage
+                                                                        }
+                                                                </em>
+                                                        </div>
+                                                )}
+                                                <button onClick={() => deleteConfluence(sync.id)}>Delete</button>
+                                                <button onClick={() => syncConfluenceNow(sync.id)}>Sync Now</button>
+                                        </li>
+                                ))}
+                        </ul>
 
 			<h2>Git Repository Syncs</h2>
 			<form onSubmit={submitGit}>
@@ -535,13 +786,13 @@ function ChatBotSyncs() {
 							</form>
 						) : (
 							<>
-								{sync.repo_full_name} - {sync.branch} (Credential:{" "}
-								{sync.credential?.name})
-								<button
-									onClick={() => {
-										setEditingGit(sync.id);
-										setEditingGitData({
-											repo_full_name: sync.repo_full_name,
+                                                                {sync.repo_full_name} - {sync.branch} (Credential:{" "}
+                                                                {sync.credential?.name})
+                                                                <button
+                                                                        onClick={() => {
+                                                                                setEditingGit(sync.id);
+                                                                                setEditingGitData({
+                                                                                        repo_full_name: sync.repo_full_name,
 											branch: sync.branch,
 											credential_id: parseInt(sync.credential?.id),
 											sync_interval: sync.sync_interval,
@@ -552,11 +803,32 @@ function ChatBotSyncs() {
 								</button>
 							</>
 						)}
-						<button onClick={() => deleteGit(sync.id)}>Delete</button>
-						<button onClick={() => syncGitNow(sync.id)}>Sync Now</button>
-					</li>
-				))}
-			</ul>
+                                                <div>
+                                                        <strong>Status:</strong> {sync.sync_status || "idle"}
+                                                        {jobDetails[makeJobKey("git", sync.id)]?.isPolling && (
+                                                                <span style={{ marginLeft: "0.5rem" }}>
+                                                                        Checking status...
+                                                                </span>
+                                                        )}
+                                                </div>
+                                                {sync.sync_status_message && (
+                                                        <div>{sync.sync_status_message}</div>
+                                                )}
+                                                {jobDetails[makeJobKey("git", sync.id)]?.jobMessage && (
+                                                        <div>
+                                                                <em>
+                                                                        Job message: {
+                                                                                jobDetails[makeJobKey("git", sync.id)]
+                                                                                        ?.jobMessage
+                                                                        }
+                                                                </em>
+                                                        </div>
+                                                )}
+                                                <button onClick={() => deleteGit(sync.id)}>Delete</button>
+                                                <button onClick={() => syncGitNow(sync.id)}>Sync Now</button>
+                                        </li>
+                                ))}
+                        </ul>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- add sync job polling and job detail tracking to the ChatBot sync management view so operators can see queued/running states
- refresh sync lists after jobs finish and surface sync status messages and job messages in the UI, including failure alerts
- log authentication session refresh failures and disable the fast refresh lint rule warning in AuthContext

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e869290a9c832a9703e8395d18ec56