### PR TITLE
Configure production static asset pipeline

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -35,8 +35,9 @@ RUN pip install --no-cache-dir --upgrade pip \
 # Copy the rest of your app
 COPY . .
 
-# Collect static assets during build so they can be served by Caddy
-RUN python manage.py collectstatic --noinput
+# Runtime entrypoint keeps the shared static volume up to date
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 # Expose the app port inside the container (Caddy reverse-proxies to this)
 EXPOSE 8000
@@ -46,4 +47,5 @@ HEALTHCHECK --interval=30s --timeout=3s --retries=3 CMD nc -z localhost 8000 || 
 
 # Default CMD: run Gunicorn (NOT runserver)
 # Tune workers/timeout as needed. 2-4 workers are fine for small EC2 instances.
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["gunicorn", "core.wsgi:application", "-b", "0.0.0.0:8000", "--workers", "3", "--timeout", "60"]

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,9 +1,14 @@
 # Use official Python image as base
 FROM python:3.11-slim
 
+ARG ENCRYPTION_KEY
+
 # Env: keep your originals
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    DJANGO_SETTINGS_MODULE=core.settings \
+    ENV=production \
+    ENCRYPTION_KEY=${ENCRYPTION_KEY}
 
 # Set working directory
 WORKDIR /app
@@ -30,9 +35,8 @@ RUN pip install --no-cache-dir --upgrade pip \
 # Copy the rest of your app
 COPY . .
 
-# (Optional) If you use Django staticfiles (admin, etc.), bake them in:
-# ENV DJANGO_SETTINGS_MODULE=core.settings
-# RUN python manage.py collectstatic --noinput
+# Collect static assets during build so they can be served by Caddy
+RUN python manage.py collectstatic --noinput
 
 # Expose the app port inside the container (Caddy reverse-proxies to this)
 EXPOSE 8000

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -149,6 +149,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = 'static/'
+STATIC_ROOT = BASE_DIR / 'staticfiles'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "${SKIP_COLLECTSTATIC}" != "1" ]; then
+  python manage.py collectstatic --noinput
+fi
+
+exec "$@"

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -5,8 +5,14 @@
   # acme_ca https://acme-v02.api.letsencrypt.org/directory
   # email you@example.com
 
-  # Proxy API to Django (Gunicorn) container
-  @api path /api* /admin/* /static/* /media*
+  # Serve collected static files directly from the shared volume
+  handle_path /static/* {
+    root * /srv/staticfiles
+    file_server
+  }
+
+  # Proxy API/Admin/other dynamic requests to Django (Gunicorn) container
+  @api path /api* /admin/* /media*
   reverse_proxy @api backend:8000
 
   # Everything else: serve the built frontend (Nginx) container

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,6 +16,7 @@ services:
       - ./deploy/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
       - caddy_config:/config
+      - staticfiles:/srv/staticfiles:ro
     depends_on:
       - frontend
       - backend
@@ -33,6 +34,8 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile.prod
+      args:
+        ENCRYPTION_KEY: ${ENCRYPTION_KEY}
     container_name: backend
     restart: unless-stopped
     env_file:
@@ -42,6 +45,8 @@ services:
       - ALLOWED_HOSTS=${FRONTEND_DOMAIN},${FRONTEND_WWW_DOMAIN}
       - CSRF_TRUSTED_ORIGINS=https://${FRONTEND_DOMAIN},https://${FRONTEND_WWW_DOMAIN}
       - CORS_ALLOWED_ORIGINS=https://${FRONTEND_DOMAIN},https://${FRONTEND_WWW_DOMAIN}
+    volumes:
+      - staticfiles:/app/staticfiles
     depends_on:
       - db
 
@@ -59,6 +64,8 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile.prod
+      args:
+        ENCRYPTION_KEY: ${ENCRYPTION_KEY}
     container_name: backend_worker
     restart: unless-stopped
     command: ["python", "manage.py", "process_sync_jobs"]
@@ -77,3 +84,4 @@ volumes:
   postgres_data:
   caddy_data:
   caddy_config:
+  staticfiles:


### PR DESCRIPTION
## Summary
- set Django's static root to a dedicated staticfiles directory
- bake collectstatic into the production backend image with required environment configuration
- mount a shared staticfiles volume and serve assets directly from Caddy in production compose

## Testing
- docker compose -f docker-compose.prod.yml build *(fails: docker is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e969a0e554832a90c56edddd63cbfa